### PR TITLE
Supports single nacos in windows

### DIFF
--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,21 +39,15 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
+          echo "Original"
+          cat nacos/8848/nacos/bin/startup.cmd
           sed '26a set MODE=\"standalone\"' nacos/8848/nacos/bin/startup.cmd
+          echo "Inserted"
+          cat nacos/8848/nacos/bin/startup.cmd
           sed '26d' nacos/8848/nacos/bin/startup.cmd
+          echo "Deleted"
           cat nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
-          mkdir -p nacos/8850
-          tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          sed '26a set MODE=\"standalone\"' nacos/8850/nacos/bin/startup.cmd
-          sed '26d' nacos/8848/nacos/bin/startup.cmd
-          sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
-          cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
-          sleep 30s
-          cat nacos/8850/nacos/logs/start.out
-          ./nacos/8848/nacos/bin/shutdown.sh
-          sleep 10s
-          ./nacos/8850/nacos/bin/shutdown.sh
-          sleep 10s
+          

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,7 +39,8 @@ jobs:
           $client = new-object System.Net.WebClient
           $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos/nacos-server.tar.gz')
           mkdir -p nacos/8848
-          7z x nacos/nacos-server.tar.gz -C nacos/8848
+          tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
+          Get-ChildItem -Path nacos/8848 -Force
           Invoke-Item nacos/8848/nacos/bin/startup.cmd
           Start-Sleep -s 30
           Get-Content nacos/8848/nacos/logs/start.out

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,7 +39,7 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          curl -OL nacos/nacos-server.tar.gz ${{ env.NACOS_BINARY_URL }}
+          curl -OL -# nacos/nacos-server.tar.gz ${{ env.NACOS_BINARY_URL }}
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           echo "ls nacos/8848"

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -40,9 +40,7 @@ jobs:
           $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos/nacos-server.tar.gz')
           mkdir -p nacos/8848
           7z x nacos/nacos-server.tar.gz -C nacos/8848
-          echo "unpack"
-          Get-ChildItem -Path nacos/8848 -Force
-          Invoke-Item nacos/8848/nacos/bin/startup.cmd -m standalone
+          Invoke-Item nacos/8848/nacos/bin/startup.cmd
           Start-Sleep -s 30
           Get-Content nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,7 +39,7 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          sed -i 's/set MODE=.*/set MODE=\"standalone\"/' nacos/8848/nacos/bin/startup.cmd
+          sed -i 's/set MODE=.*/set MODE=\"standalone\"/g' nacos/8848/nacos/bin/startup.cmd
           cat nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -40,6 +40,7 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           sed -i 's/set MODE=.*/set MODE=\"standalone\"/' nacos/8848/nacos/bin/startup.cmd
+          cat nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -41,9 +41,9 @@ jobs:
           mkdir -p nacos
           curl ${{ env.NACOS_BINARY_URL }} >> nacos/nacos-server.tar.gz
           echo "ls nacos"
-          ls nacos
+          ls -arlt nacos
           mkdir -p nacos/8848
-          tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
+          tar -xvf nacos/nacos-server.tar.gz -C nacos/8848
           echo "ls nacos/8848"
           ls nacos/8848
           ./nacos/8848/nacos/bin/startup.sh -m standalone

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -43,14 +43,14 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           sed -i 's/set MODE=.*/set MODE=\"standalone\"/g' nacos/8848/nacos/bin/startup.cmd
-          cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
+          ./nacos/8848/nacos/bin/startup.sh
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
           sed -i 's/set MODE=.*/set MODE=\"standalone\"/g' nacos/8850/nacos/bin/startup.cmd
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
-          cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
+          ./nacos/8850/nacos/bin/startup.sh
           sleep 30s
           cat nacos/8850/nacos/logs/start.out
           ./nacos/8848/nacos/bin/shutdown.sh

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,11 +39,12 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          curl ${{ env.NACOS_BINARY_URL }} >> nacos/nacos-server.tar.gz
+          cd nacos
+          curl ${{ env.NACOS_BINARY_URL }}
           echo "ls nacos"
           ls -arlt nacos
           mkdir -p nacos/8848
-          tar -xvf nacos/nacos-server.tar.gz -C nacos/8848
+          tar -xvf nacos-server.tar.gz -C 8848
           echo "ls nacos/8848"
           ls nacos/8848
           ./nacos/8848/nacos/bin/startup.sh -m standalone

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -36,10 +36,10 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          echo "dir nacos"
-          dir nacos
+          echo "dir ~"
+          dir ~
           echo "get NACOS_BINARY_URL value"
-          echo %NACOS_BINARY_URL%
+          echo $NACOS_BINARY_URL
           curl %NACOS_BINARY_URL% -o nacos\nacos-server.tar.gz
           mkdir -p nacos\8848
           7z x nacos/nacos-server.tar.gz -C nacos\8848

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -47,7 +47,9 @@ jobs:
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties
+          sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties > nacos/8850/nacos/conf/application.properties.temp
+          echo "cat nacos/8850/nacos/conf/application.properties.temp"
+          cat nacos/8850/nacos/conf/application.properties.temp
           ./nacos/8850/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8850/nacos/logs/start.out

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -13,7 +13,7 @@ jobs:
       - name: "nacos lifecycle ubuntu"
         run: |
           mkdir -p nacos
-          wget -O nacos/nacos-server.tar.gz -c -N --tries=3 --show-progress $NACOS_BINARY_URL
+          wget -O nacos/nacos-server.tar.gz -c -N --tries=3 --show-progress ${{ env.NACOS_BINARY_URL }}
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           ./nacos/8848/nacos/bin/startup.sh -m standalone
@@ -36,9 +36,12 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          echo "get NACOS_BINARY_URL value"
           echo ${{ env.NACOS_BINARY_URL }}
-          curl ${{ env.NACOS_BINARY_URL }} -o nacos\nacos-server.tar.gz
+          echo "Download the file"
+          $client = new-object System.Net.WebClient
+          $client.DownloadFile(${{ env.NACOS_BINARY_URL }}, 'nacos\nacos-server.tar.gz')
+          echo "list downloaded files"
+          tree nacos
           mkdir -p nacos\8848
           7z x nacos/nacos-server.tar.gz -C nacos\8848
           .\nacos\8848\nacos\bin\startup.cmd -m standalone

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -32,7 +32,9 @@ jobs:
           
   nacos-lifecycle-windows:
     runs-on: windows-2019
-    shell: bash
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: "nacos lifecycle windows"
         run: |

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,14 +39,7 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          echo "Original"
-          cat nacos/8848/nacos/bin/startup.cmd
-          sed '26a set MODE=\"standalone\"' nacos/8848/nacos/bin/startup.cmd
-          echo "Inserted"
-          cat nacos/8848/nacos/bin/startup.cmd
-          sed '26d' nacos/8848/nacos/bin/startup.cmd
-          echo "Deleted"
-          cat nacos/8848/nacos/bin/startup.cmd
+          sed -i 's/set MODE=.*/set MODE=\"standalone\"/' nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,7 +39,7 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          curl -C -O ${{ env.NACOS_BINARY_URL }} >> nacos/nacos-server.tar.gz
+          curl ${{ env.NACOS_BINARY_URL }} >> nacos/nacos-server.tar.gz
           echo "ls nacos"
           ls nacos
           mkdir -p nacos/8848

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -41,7 +41,11 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           Get-ChildItem -Path nacos/8848 -Force
+          echo "update before"
+          Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sed -i "s#^set MODE=.*#set MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
+          echo "update after"
+          Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           Start-Sleep -s 30
           echo "get nacos-server process 8848"

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -40,8 +40,6 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           sed -i 's/set MODE=.*/set MODE=\"standalone\"/g' nacos/8848/nacos/bin/startup.cmd
-          cat nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
-          

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -43,6 +43,8 @@ jobs:
           Get-ChildItem -Path nacos/8848 -Force
           Invoke-Item nacos/8848/nacos/bin/startup.cmd
           Start-Sleep -s 30
+          echo "get nacos-server process"
+          get-process nacos-server
           Get-Content nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -40,7 +40,7 @@ jobs:
           $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos/nacos-server.tar.gz')
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          (Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd).replace('[set MODE="cluster"]', 'set MODE="standalone"') | Set-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
+          (Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd).replace('[set MODE=\"cluster\"]', 'set MODE=\"standalone\"') | Set-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           echo "update after"
           Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -40,11 +40,12 @@ jobs:
         run: |
           mkdir -p nacos
           cd nacos
-          curl ${{ env.NACOS_BINARY_URL }}
-          echo "ls"
-          ls -arlt
+          curl -# ${{ env.NACOS_BINARY_URL }}
+          cd ..
+          echo "ls nacos"
+          ls -arlt nacos
           mkdir -p nacos/8848
-          tar -xvf nacos-server.tar.gz -C 8848
+          tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           echo "ls nacos/8848"
           ls nacos/8848
           ./nacos/8848/nacos/bin/startup.sh -m standalone

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - name: "nacos lifecycle windows"
         run: |
+          yum -y install wget
           mkdir -p nacos
           wget -O nacos/nacos-server.tar.gz -c -N --tries=3 --show-progress ${{ env.NACOS_BINARY_URL }}
           mkdir -p nacos/8848

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -41,7 +41,7 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           Get-ChildItem -Path nacos/8848 -Force
-          Invoke-Item nacos/8848/nacos/bin/startup.cmd
+          cmd /c nacos/8848/nacos/bin/startup.cmd
           Start-Sleep -s 30
           echo "get nacos-server process"
           get-process nacos-server

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,11 +39,7 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          cd nacos
-          curl -# ${{ env.NACOS_BINARY_URL }}
-          cd ..
-          echo "ls nacos"
-          ls -arlt nacos
+          curl -OL nacos/nacos-server.tar.gz ${{ env.NACOS_BINARY_URL }}
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           echo "ls nacos/8848"

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -32,6 +32,9 @@ jobs:
           
   nacos-lifecycle-windows:
     runs-on: windows-2019
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: "nacos lifecycle windows"
         run: |

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -36,17 +36,13 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          echo ${{ env.NACOS_BINARY_URL }}
-          echo "Download the file"
-          $client = new-object System.Net.WebClient
-          $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos\nacos-server.tar.gz')
-          echo "list downloaded files"
-          tree nacos
+          wget -O nacos/nacos-server.tar.gz -c -N --tries=3 --show-progress ${{ env.NACOS_BINARY_URL }}
           mkdir -p nacos\8848
           7z x nacos/nacos-server.tar.gz -C nacos\8848
-          .\nacos\8848\nacos\bin\startup.cmd -m standalone
+          tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
+          ./nacos/8848/nacos/bin/startup.sh -m standalone
           sleep 30s
-          cat nacos\8848\nacos\logs\start.out
+          cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
           sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -40,10 +40,7 @@ jobs:
           $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos/nacos-server.tar.gz')
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          Get-ChildItem -Path nacos/8848 -Force
-          echo "update before"
-          Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
-          sed -i "s#^MODE=.*#MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
+          sed -i "" "s#^set MODE=.*#set MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           echo "update after"
           Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
@@ -53,9 +50,7 @@ jobs:
           Get-Content nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          Get-ChildItem -Path nacos/8850 -Force
-          sed -i "s#^set MODE=.*#set MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
-          sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties
+          sed -i "" "s#^set MODE=.*#set MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           Start-Sleep –s 30
           echo "get nacos-server process 8850"

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -36,11 +36,9 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          echo "dir ~"
-          dir ~
           echo "get NACOS_BINARY_URL value"
-          echo $NACOS_BINARY_URL
-          curl %NACOS_BINARY_URL% -o nacos\nacos-server.tar.gz
+          echo ${{ env.NACOS_BINARY_URL }}
+          curl ${{ env.NACOS_BINARY_URL }} -o nacos\nacos-server.tar.gz
           mkdir -p nacos\8848
           7z x nacos/nacos-server.tar.gz -C nacos\8848
           .\nacos\8848\nacos\bin\startup.cmd -m standalone

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,13 +39,13 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          sed -i 's/MODE="cluster"/MODE="standalone"/g' nacos/8848/nacos/bin/startup.cmd
+          sed -i "s/set MODE=\"cluster\"/set MODE=\"standalone\"/g' nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          sed -i 's/MODE="cluster"/MODE="standalone"/g' nacos/8850/nacos/bin/startup.cmd
+          sed -i "s/set MODE=\"cluster\"/set MODE=\"standalone\"/g' nacos/8850/nacos/bin/startup.cmd
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
           cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           sleep 30s

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -41,8 +41,8 @@ jobs:
           mkdir -p nacos
           cd nacos
           curl ${{ env.NACOS_BINARY_URL }}
-          echo "ls nacos"
-          ls -arlt nacos
+          echo "ls"
+          ls -arlt
           mkdir -p nacos/8848
           tar -xvf nacos-server.tar.gz -C 8848
           echo "ls nacos/8848"

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -36,7 +36,11 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          curl $NACOS_BINARY_URL -o nacos\nacos-server.tar.gz
+          echo "dir nacos"
+          dir nacos
+          echo "get NACOS_BINARY_URL value"
+          echo %NACOS_BINARY_URL%
+          curl %NACOS_BINARY_URL% -o nacos\nacos-server.tar.gz
           mkdir -p nacos\8848
           7z x nacos/nacos-server.tar.gz -C nacos\8848
           .\nacos\8848\nacos\bin\startup.cmd -m standalone

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -47,9 +47,9 @@ jobs:
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties > nacos/8850/nacos/conf/application.properties.temp
-          echo "cat nacos/8850/nacos/conf/application.properties.temp"
-          cat nacos/8850/nacos/conf/application.properties.temp
+          sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
+          echo "cat nacos/8850/nacos/conf/application.properties"
+          cat nacos/8850/nacos/conf/application.properties
           ./nacos/8850/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8850/nacos/logs/start.out

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -38,18 +38,11 @@ jobs:
           mkdir -p nacos
           $client = new-object System.Net.WebClient
           $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos/nacos-server.tar.gz')
-          echo "ls nacos"
-          Get-ChildItem -Path nacos -Force
           mkdir -p nacos/8848
-          echo "ls nacos/8848"
-          Get-ChildItem -Path nacos/8848 -Force
           7z x nacos/nacos-server.tar.gz -C nacos/8848
           echo "unpack"
           Get-ChildItem -Path nacos/8848 -Force
-          echo "tar"
-          tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          Get-ChildItem -Path nacos/8848 -Force
-          ./nacos/8848/nacos/bin/startup.sh -m standalone
+          Invoke-Item nacos/8848/nacos/bin/startup.cmd -m standalone
           Start-Sleep -s 30
           Get-Content nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -38,12 +38,11 @@ jobs:
     steps:
       - name: "nacos lifecycle windows"
         run: |
-          curl www.baidu.com
           mkdir -p nacos
-          wget -O nacos/nacos-server.tar.gz -c -N --tries=3 --show-progress ${{ env.NACOS_BINARY_URL }}
-          mkdir -p nacos/8848
+          curl -C -O ${{ env.NACOS_BINARY_URL }} >> nacos/nacos-server.tar.gz
           echo "ls nacos"
           ls nacos
+          mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           echo "ls nacos/8848"
           ls nacos/8848

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -40,7 +40,7 @@ jobs:
           $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos/nacos-server.tar.gz')
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          sed -i "" "s#^set MODE=.*#set MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
+          (Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd).replace('[set MODE="cluster"]', 'set MODE="standalone"') | Set-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           echo "update after"
           Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
@@ -50,7 +50,7 @@ jobs:
           Get-Content nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          sed -i "" "s#^set MODE=.*#set MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
+          (Get-Content ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd).replace('[set MODE="cluster"]', 'set MODE="standalone"') | Set-Content ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           Start-Sleep –s 30
           echo "get nacos-server process 8850"

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -41,19 +41,23 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           Get-ChildItem -Path nacos/8848 -Force
-          set MODE="standalone"
+          sed -i "s#^set MODE=.*#set MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           Start-Sleep -s 30
-          echo "get nacos-server process"
+          echo "get nacos-server process 8848"
           get-process nacos-server
           Get-Content nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
+          Get-ChildItem -Path nacos/8850 -Force
+          sed -i "s#^set MODE=.*#set MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties
-          ./nacos/8850/nacos/bin/startup.sh -m standalone
-          sleep 30s
-          cat nacos/8850/nacos/logs/start.out
-          ./nacos/8848/nacos/bin/shutdown.sh
-          sleep 10s
-          ./nacos/8850/nacos/bin/shutdown.sh
-          sleep 10s
+          cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
+          Start-Sleep –s 30
+          echo "get nacos-server process 8850"
+          get-process nacos-server
+          Get-Content nacos/8850/nacos/logs/start.out
+          cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/shutdown.sh
+          Start-Sleep –s 10
+          cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/shutdown.sh
+          Start-Sleep –s 10

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,19 +39,16 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          sed '26d' nacos/8848/nacos/bin/startup.cmd
-          echo "delete MODE"
-          cat nacos/8848/nacos/bin/startup.cmd
-          echo "insert MODE"
           sed '26a set MODE=\"standalone\"' nacos/8848/nacos/bin/startup.cmd
+          sed '26d' nacos/8848/nacos/bin/startup.cmd
           cat nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          sed '26d' nacos/8850/nacos/bin/startup.cmd
           sed '26a set MODE=\"standalone\"' nacos/8850/nacos/bin/startup.cmd
+          sed '26d' nacos/8848/nacos/bin/startup.cmd
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
           cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           sleep 30s

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -7,10 +7,10 @@ env:
   NACOS_BINARY_URL: https://github.com/alibaba/nacos/releases/download/2.0.3/nacos-server-2.0.3.tar.gz
 
 jobs:
-  nacos-lifecycle:
+  nacos-lifecycle-ubuntu:
     runs-on: ubuntu-18.04
     steps:
-      - name: "nacos lifecycle"
+      - name: "nacos lifecycle ubuntu"
         run: |
           mkdir -p nacos
           wget -O nacos/nacos-server.tar.gz -c -N --tries=3 --show-progress $NACOS_BINARY_URL
@@ -19,6 +19,29 @@ jobs:
           ./nacos/8848/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
+          mkdir -p nacos/8850
+          tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
+          sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties
+          ./nacos/8850/nacos/bin/startup.sh -m standalone
+          sleep 30s
+          cat nacos/8850/nacos/logs/start.out
+          ./nacos/8848/nacos/bin/shutdown.sh
+          sleep 10s
+          ./nacos/8850/nacos/bin/shutdown.sh
+          sleep 10s
+          
+  nacos-lifecycle-windows:
+    runs-on: windows-2019
+    steps:
+      - name: "nacos lifecycle windows"
+        run: |
+          mkdir -p nacos
+          curl $NACOS_BINARY_URL -o nacos\nacos-server.tar.gz
+          mkdir -p nacos\8848
+          7z x nacos/nacos-server.tar.gz -C nacos\8848
+          .\nacos\8848\nacos\bin\startup.cmd -m standalone
+          sleep 30s
+          cat nacos\8848\nacos\logs\start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
           sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -32,31 +32,28 @@ jobs:
           
   nacos-lifecycle-windows:
     runs-on: windows-2019
+    shell: bash
     steps:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          $client = new-object System.Net.WebClient
-          $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos/nacos-server.tar.gz')
+          wget -O nacos/nacos-server.tar.gz -c -N --tries=3 --show-progress ${{ env.NACOS_BINARY_URL }}
           mkdir -p nacos/8848
+          echo "ls nacos"
+          ls nacos
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          (Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd).replace('[set MODE=\"cluster\"]', 'set MODE=\"standalone\"') | Set-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
-          echo "update after"
-          Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
-          cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
-          Start-Sleep -s 30
-          echo "get nacos-server process 8848"
-          get-process nacos-server
-          Get-Content nacos/8848/nacos/logs/start.out
+          echo "ls nacos/8848"
+          ls nacos/8848
+          ./nacos/8848/nacos/bin/startup.sh -m standalone
+          sleep 30s
+          cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          (Get-Content ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd).replace('[set MODE="cluster"]', 'set MODE="standalone"') | Set-Content ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
-          cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
-          Start-Sleep –s 30
-          echo "get nacos-server process 8850"
-          get-process nacos-server
-          Get-Content nacos/8850/nacos/logs/start.out
-          cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/shutdown.sh
-          Start-Sleep –s 10
-          cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/shutdown.sh
-          Start-Sleep –s 10
+          sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties
+          ./nacos/8850/nacos/bin/startup.sh -m standalone
+          sleep 30s
+          cat nacos/8850/nacos/logs/start.out
+          ./nacos/8848/nacos/bin/shutdown.sh
+          sleep 10s
+          ./nacos/8850/nacos/bin/shutdown.sh
+          sleep 10s

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -47,13 +47,7 @@ jobs:
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          echo "ls nacos/8850"
-          ls -alrt nacos/8850
-          echo "before cat nacos/8850/nacos/conf/application.properties"
-          cat nacos/8850/nacos/conf/application.properties
           sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties
-          echo "after cat nacos/8850/nacos/conf/application.properties"
-          cat nacos/8850/nacos/conf/application.properties
           ./nacos/8850/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8850/nacos/logs/start.out

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,13 +39,13 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          sed -i "s/set MODE=\"cluster\"/set MODE=\"standalone\"/g' nacos/8848/nacos/bin/startup.cmd
+          sed -i "s/set MODE=.*/set MODE=\"standalone\"/g" nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          sed -i "s/set MODE=\"cluster\"/set MODE=\"standalone\"/g' nacos/8850/nacos/bin/startup.cmd
+          sed -i "s/set MODE=.*/set MODE=\"standalone\"/g" nacos/8850/nacos/bin/startup.cmd
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
           cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           sleep 30s

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -42,14 +42,18 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          echo "ls nacos/8848"
-          ls nacos/8848
           ./nacos/8848/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
+          echo "ls nacos/8850"
+          ls -alrt nacos/8850
+          echo "before cat nacos/8850/nacos/conf/application.properties"
+          cat nacos/8850/nacos/conf/application.properties
           sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties
+          echo "after cat nacos/8850/nacos/conf/application.properties"
+          cat nacos/8850/nacos/conf/application.properties
           ./nacos/8850/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8850/nacos/logs/start.out

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -40,8 +40,10 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           sed '26d' nacos/8848/nacos/bin/startup.cmd
+          echo "delete MODE"
           cat nacos/8848/nacos/bin/startup.cmd
-          sed '25a set MODE="standalone"' nacos/8848/nacos/bin/startup.cmd
+          echo "insert MODE"
+          sed '26a set MODE=\"standalone\"' nacos/8848/nacos/bin/startup.cmd
           cat nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
@@ -49,7 +51,7 @@ jobs:
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
           sed '26d' nacos/8850/nacos/bin/startup.cmd
-          sed '25a set MODE="standalone"' nacos/8850/nacos/bin/startup.cmd
+          sed '26a set MODE=\"standalone\"' nacos/8850/nacos/bin/startup.cmd
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
           cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           sleep 30s

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -36,7 +36,6 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          wget -Uri ${{ env.NACOS_BINARY_URL }} -OutFile nacos/nacos-server.tar.gz
           $client = new-object System.Net.WebClient
           $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos')
           mkdir -p nacos\8848

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,14 +39,14 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          sed -i "s/set MODE=.*/set MODE=\"standalone\"/g" nacos/8848/nacos/bin/startup.cmd
+          sed -i "s#set MODE=.*#set MODE=\"standalone\"#g" nacos/8848/nacos/bin/startup.cmd
           echo nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          sed -i "s/set MODE=.*/set MODE=\"standalone\"/g" nacos/8850/nacos/bin/startup.cmd
+          sed -i "s#set MODE=.*#set MODE=\"standalone\"#g" nacos/8850/nacos/bin/startup.cmd
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
           cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           sleep 30s

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -50,6 +50,10 @@ jobs:
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
           sed -i 's/set MODE=.*/set MODE=\"standalone\"/g' nacos/8850/nacos/bin/startup.cmd
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
+          echo "nacos/8850/nacos/bin/startup.cmd"
+          cat nacos/8850/nacos/bin/startup.cmd
+          echo "nacos/8850/nacos/conf/application.properties"
+          cat nacos/8850/nacos/conf/application.properties
           ./nacos/8850/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8850/nacos/logs/start.out

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -40,6 +40,7 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           sed -i "s/set MODE=.*/set MODE=\"standalone\"/g" nacos/8848/nacos/bin/startup.cmd
+          echo nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -41,6 +41,7 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           Get-ChildItem -Path nacos/8848 -Force
+          set MODE="standalone"
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           Start-Sleep -s 30
           echo "get nacos-server process"

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -32,9 +32,6 @@ jobs:
           
   nacos-lifecycle-windows:
     runs-on: windows-2019
-    defaults:
-      run:
-        shell: bash
     steps:
       - name: "nacos lifecycle windows"
         run: |
@@ -42,14 +39,12 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          ./nacos/8848/nacos/bin/startup.sh -m standalone
+          cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
-          echo "cat nacos/8850/nacos/conf/application.properties"
-          cat nacos/8850/nacos/conf/application.properties
           ./nacos/8850/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8850/nacos/logs/start.out

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -36,7 +36,9 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          wget -O nacos/nacos-server.tar.gz -c -N --tries=3 --show-progress ${{ env.NACOS_BINARY_URL }}
+          wget -Uri ${{ env.NACOS_BINARY_URL }} -OutFile nacos/nacos-server.tar.gz
+          $client = new-object System.Net.WebClient
+          $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos')
           mkdir -p nacos\8848
           7z x nacos/nacos-server.tar.gz -C nacos\8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -43,7 +43,7 @@ jobs:
           Get-ChildItem -Path nacos/8848 -Force
           echo "update before"
           Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
-          sed -i "s#^set MODE=.*#set MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
+          sed -i "s#^MODE=.*#MODE=\"standalone\"#g" ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           echo "update after"
           Get-Content ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,13 +39,15 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
+          sed -i 's/MODE="cluster"/MODE="standalone"/g' nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
+          sed -i 's/MODE="cluster"/MODE="standalone"/g' nacos/8850/nacos/bin/startup.cmd
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
-          ./nacos/8850/nacos/bin/startup.sh -m standalone
+          cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8850/nacos/logs/start.out
           ./nacos/8848/nacos/bin/shutdown.sh

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: "nacos lifecycle windows"
         run: |
-          yum -y install wget
+          curl www.baidu.com
           mkdir -p nacos
           wget -O nacos/nacos-server.tar.gz -c -N --tries=3 --show-progress ${{ env.NACOS_BINARY_URL }}
           mkdir -p nacos/8848

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -38,12 +38,20 @@ jobs:
           mkdir -p nacos
           $client = new-object System.Net.WebClient
           $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos/nacos-server.tar.gz')
-          mkdir -p nacos\8848
-          7z x nacos/nacos-server.tar.gz -C nacos\8848
+          echo "ls nacos"
+          Get-ChildItem -Path nacos -Force
+          mkdir -p nacos/8848
+          echo "ls nacos/8848"
+          Get-ChildItem -Path nacos/8848 -Force
+          7z x nacos/nacos-server.tar.gz -C nacos/8848
+          echo "unpack"
+          Get-ChildItem -Path nacos/8848 -Force
+          echo "tar"
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
+          Get-ChildItem -Path nacos/8848 -Force
           ./nacos/8848/nacos/bin/startup.sh -m standalone
-          sleep 30s
-          cat nacos/8848/nacos/logs/start.out
+          Start-Sleep -s 30
+          Get-Content nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
           sed -i "s#^server.port=.*#server.port=8850#g" nacos/8850/nacos/conf/application.properties

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -46,18 +46,5 @@ jobs:
           ./nacos/8848/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
-          mkdir -p nacos/8850
-          tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          sed -i 's/set MODE=.*/set MODE=\"standalone\"/g' nacos/8850/nacos/bin/startup.cmd
-          sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
-          echo "nacos/8850/nacos/bin/startup.cmd"
-          cat nacos/8850/nacos/bin/startup.cmd
-          echo "nacos/8850/nacos/conf/application.properties"
-          cat nacos/8850/nacos/conf/application.properties
-          ./nacos/8850/nacos/bin/startup.sh -m standalone
-          sleep 30s
-          cat nacos/8850/nacos/logs/start.out
           ./nacos/8848/nacos/bin/shutdown.sh
-          sleep 10s
-          ./nacos/8850/nacos/bin/shutdown.sh
           sleep 10s

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,7 +39,7 @@ jobs:
       - name: "nacos lifecycle windows"
         run: |
           mkdir -p nacos
-          curl -OL -# nacos/nacos-server.tar.gz ${{ env.NACOS_BINARY_URL }}
+          curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           echo "ls nacos/8848"

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -46,5 +46,3 @@ jobs:
           ./nacos/8848/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
-          ./nacos/8848/nacos/bin/shutdown.sh
-          sleep 10s

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,7 +39,7 @@ jobs:
           echo ${{ env.NACOS_BINARY_URL }}
           echo "Download the file"
           $client = new-object System.Net.WebClient
-          $client.DownloadFile(${{ env.NACOS_BINARY_URL }}, 'nacos\nacos-server.tar.gz')
+          $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos\nacos-server.tar.gz')
           echo "list downloaded files"
           tree nacos
           mkdir -p nacos\8848

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -41,7 +41,7 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           Get-ChildItem -Path nacos/8848 -Force
-          cmd /c nacos/8848/nacos/bin/startup.cmd
+          cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           Start-Sleep -s 30
           echo "get nacos-server process"
           get-process nacos-server

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -43,3 +43,14 @@ jobs:
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
+          mkdir -p nacos/8850
+          tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
+          sed -i 's/set MODE=.*/set MODE=\"standalone\"/g' nacos/8850/nacos/bin/startup.cmd
+          sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
+          cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
+          sleep 30s
+          cat nacos/8850/nacos/logs/start.out
+          ./nacos/8848/nacos/bin/shutdown.sh
+          sleep 10s
+          ./nacos/8850/nacos/bin/shutdown.sh
+          sleep 10s

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           mkdir -p nacos
           $client = new-object System.Net.WebClient
-          $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos')
+          $client.DownloadFile('${{ env.NACOS_BINARY_URL }}', 'nacos/nacos-server.tar.gz')
           mkdir -p nacos\8848
           7z x nacos/nacos-server.tar.gz -C nacos\8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -43,14 +43,14 @@ jobs:
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
           sed -i 's/set MODE=.*/set MODE=\"standalone\"/g' nacos/8848/nacos/bin/startup.cmd
-          ./nacos/8848/nacos/bin/startup.sh
+          ./nacos/8848/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
           sed -i 's/set MODE=.*/set MODE=\"standalone\"/g' nacos/8850/nacos/bin/startup.cmd
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
-          ./nacos/8850/nacos/bin/startup.sh
+          ./nacos/8850/nacos/bin/startup.sh -m standalone
           sleep 30s
           cat nacos/8850/nacos/logs/start.out
           ./nacos/8848/nacos/bin/shutdown.sh

--- a/.github/workflows/nacos-lifecycle.yml
+++ b/.github/workflows/nacos-lifecycle.yml
@@ -39,14 +39,17 @@ jobs:
           curl -L -# ${{ env.NACOS_BINARY_URL }} -o nacos/nacos-server.tar.gz
           mkdir -p nacos/8848
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8848
-          sed -i "s#set MODE=.*#set MODE=\"standalone\"#g" nacos/8848/nacos/bin/startup.cmd
-          echo nacos/8848/nacos/bin/startup.cmd
+          sed '26d' nacos/8848/nacos/bin/startup.cmd
+          cat nacos/8848/nacos/bin/startup.cmd
+          sed '25a set MODE="standalone"' nacos/8848/nacos/bin/startup.cmd
+          cat nacos/8848/nacos/bin/startup.cmd
           cmd /c ${{ github.workspace }}/nacos/8848/nacos/bin/startup.cmd
           sleep 30s
           cat nacos/8848/nacos/logs/start.out
           mkdir -p nacos/8850
           tar -zxvf nacos/nacos-server.tar.gz -C nacos/8850
-          sed -i "s#set MODE=.*#set MODE=\"standalone\"#g" nacos/8850/nacos/bin/startup.cmd
+          sed '26d' nacos/8850/nacos/bin/startup.cmd
+          sed '25a set MODE="standalone"' nacos/8850/nacos/bin/startup.cmd
           sed -i "s/server.port=.*/server.port=8850/g" nacos/8850/nacos/conf/application.properties
           cmd /c ${{ github.workspace }}/nacos/8850/nacos/bin/startup.cmd
           sleep 30s


### PR DESCRIPTION
We can use [bash shell and Powershell ](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell)to manage the lifecycle of nacos in Windows.

However, bash shell included with Git for Windows is used. That means there some Linux Commands cannot support, so there are some strange problem occurred, such as cannot use `wget` to download file, use `sed` to update configuration file successfully but failed to run because it still used the previous configuration file to run, cannot run `shutdown.sh` to destroy the started nacos-server process.

Of cause, we can use `Powershell` to solve all of these problem, because windows supports `Powershell` better. Unfortunately, `Powershell` is very difficult to use

Summary, this PR is incomplete, and the supported functions are
+ Download nacos-server-2.0.3.tar.gz
+ Unpack nacos-server-2.0.3.tar.gz
+ Update `cluster` to `standalone` in `startup.cmd` file
+ Start nacos server use bash shell to run `startup.sh`

the unsupported functions are
+ Shutdown the started nacos server instance (failed to use `shutdown.sh` to destroy the nacos server instance)
+ Cannot started the other nacos server instance because of port is aready in used, although we modified the port successfully